### PR TITLE
docs: add pnpm and Drizzle to backend tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 **Backend**
 * NestJS (Node.js framework)
 * TypeScript
+* pnpm (Package manager)
+* Drizzle (ORM)
 
 **Frontend**
 * Next.js (React framework)


### PR DESCRIPTION
## Changes

Add pnpm (package manager) and Drizzle (ORM) to the Backend tech stack section in README.md to accurately reflect the project's dependencies.

## How did you test this code?

Verified the README.md renders correctly with the added tech stack entries.

## Related Issue

N/A

---

## Testing Checklist

- [x] I have tested my changes locally
- [x] I have run `pnpm run lint` and fixed all errors
- [x] I have run `pnpm run build` and it succeeds
- [x] I have run `pnpm run test` and all tests pass

## Contribution Checklist

- [x] My branch is up to date with upstream/main
- [x] My changes are focused on a single task (granular PR)
- [x] I have followed the project's code style guidelines
- [x] I have updated any relevant documentation
- [x] My commit messages are clear and descriptive
- [ ] I have linked the related issue/ticket
- [ ] All acceptance criteria from the ticket are met