### PR TITLE
docs(docs): add getting started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 |Contributor | abhisar |  —  | [GitHub](https://github.com/abhisar7) |
 |Contributor | RitamJuniorPal |  —  | [GitHub](https://github.com/RitamPal26) |
 |Contributor | Ayushi  |  —  | [GitHub](https://github.com/19-ayushi)|
+## Getting Started
+
+For setup instructions, prerequisites, and development commands, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds a "Getting Started" section to the README.md to guide newcomers 
on how to set up the project. It points users to the existing CONTRIBUTING.md 
for setup instructions, prerequisites, and development commands.

Changes made:
- Added "## Getting Started" section after the "File Structure" section
  in README.md with a link to CONTRIBUTING.md.

This improves the onboarding experience for new contributors.
