### PR TITLE
docs: add getting started section to README (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 └── README.md             # Project documentation 
 
 ```   
+## Getting Started
+
+For setup instructions, prerequisites, and development commands, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 
 ## Project Team
 


### PR DESCRIPTION
## Changes
Added a "Getting Started" section to README.md pointing to CONTRIBUTING.md, so newcomers know where to find setup instructions.

## How did you test this code?
Verified locally that the README displays the Getting Started section correctly.

## Related Issue
Closes #41

## Testing Checklist
- [x] I have tested my changes locally
- [x] Documentation update only, no build or lint errors

## Contribution Checklist
- [x] My branch is up to date with upstream/main
- [x] Changes are focused on a single task (documentation)
- [x] I have followed the project's code style guidelines
- [x] I have updated any relevant documentation
- [x] My commit messages are clear and descriptive
- [x] I have linked the related issue/ticket
