### PR TITLE
docs: add getting started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 |Contributor | abhisar |  —  | [GitHub](https://github.com/abhisar7) |
 |Contributor | RitamJuniorPal |  —  | [GitHub](https://github.com/RitamPal26) |
 |Contributor | Ayushi  |  —  | [GitHub](https://github.com/19-ayushi)|
+## Getting Started
+
+For setup instructions, prerequisites, and development commands, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Changes

Added a "Getting Started" section to README.md that points newcomers to CONTRIBUTING.md for setup instructions, prerequisites, and development commands.

## How did you test this code?

- Opened README.md locally to confirm the new section appears correctly after the File Structure section.
- Verified the link to CONTRIBUTING.md works in the preview.

## Related Issue

Closes #44

---

## Testing Checklist

- [x] I have tested my changes locally
- [ ] I have run `pnpm run lint` and fixed all errors
- [ ] I have run `pnpm run build` and it succeeds
- [ ] I have run `pnpm run test` and all tests pass

## Contribution Checklist

- [x] My branch is up to date with upstream/main
- [x] My changes are focused on a single task (granular PR)
- [x] I have followed the project's code style guidelines
- [x] I have updated any relevant documentation
- [x] My commit messages are clear and descriptive
- [x] I have linked the related issue/ticket
- [x] All acceptance criteria from the ticket are met
