### PR TITLE
chore(docker): removed obsolete version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
## Changes

- Removed the obsolete `version: '3.8'` line from `docker-compose.yml`.
- This fixes the warning: `WARN[0000] ... the attribute 'version' is obsolete`.

## How did you test this code?

- Ran `docker-compose up` locally.
- Verified that the "attribute version is obsolete" warning no longer appears in the terminal.
- Confirmed that the docker configuration is still valid and services attempt to start.

## Related Issue

Closes #46

---

## Testing Checklist

- [x] I have tested my changes locally
- [x] The version key is removed from docker-compose.yml
- [x] docker compose up and docker compose down produce no warnings

## Contribution Checklist

- [x] My branch is up to date with upstream/main
- [x] My changes are focused on a single task (granular PR)
- [x] I have followed the project's code style guidelines
- [x] I have updated any relevant documentation
- [x] My commit messages are clear and descriptive
- [x] I have linked the related issue/ticket
- [x] All acceptance criteria from the ticket are met
