### PR TITLE
docs(root): add missing LinkedIn links for team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 
 | Role | Discord | LinkedIn | GitHub |
 |------|------|----------|--------|
-| Contributor | Samuell |  —  | [GitHub](https://github.com/TraveledTiger) |
-| Contributor | Sniper |  — | [GitHub](https://github.com/ajiva84) |
-| Contributor | VooDooRe |  —  | [GitHub](https://github.com/nurmukhammad03) |
+| Contributor | Samuell | [LinkedIn](https://www.linkedin.com/in/samuel-n-brown/)  | [GitHub](https://github.com/TraveledTiger) |
+| Contributor | Sniper | [LinkedIn](https://www.linkedin.com/in/azamjiva/)   | [GitHub](https://github.com/ajiva84) |
+| Contributor | VooDooRe |  [LinkedIn](http://www.linkedin.com/in/nurmukhammad-sayfiddinov-3709851bb)  | [GitHub](https://github.com/nurmukhammad03) |
 | Contributor | DayDayUp23 | [LinkedIn](https://www.linkedin.com/in/william-d-miller-jr) | [GitHub](https://github.com/bijiyiqi2017) |
 
 
@@ -70,9 +70,10 @@ Repository for Team teal-iris - Spring 2026 Cohort. It is structured as a monore
 |------|------|----------|--------|
 | Contributor | Tihomir| [LinkedIn](https://www.linkedin.com/in/tihomir-manushev-066782b3/) | [GitHub](https://github.com/haraGADygyl) |
 |Contributor | SirLancelot | [LinkedIn](https://www.linkedin.com/in/pragyan-srivastava-ba3b24383/) | [GitHub](https://github.com/SirLancelot-13) |
-|Contributor | abhisar |  —  | [GitHub](https://github.com/abhisar7) |
-|Contributor | RitamJuniorPal |  —  | [GitHub](https://github.com/RitamPal26) |
-|Contributor | Ayushi  |  —  | [GitHub](https://github.com/19-ayushi)|
+|Contributor | abhisar |  [LinkedIn](https://www.linkedin.com/in/abhisar-kumar-588ab7226)  | [GitHub](https://github.com/abhisar7) |
+|Contributor | RitamJuniorPal |  [LinkedIn](https://www.linkedin.com/in/ritam-pal-124175244/)  | [GitHub](https://github.com/RitamPal26) |
+|Contributor | Ayushi  |  [LinkedIn](https://www.linkedin.com/in/ayushi-agrawal-216582234/)  | [GitHub](https://github.com/19-ayushi)|
+
 ## Getting Started
 
 For setup instructions, prerequisites, and development commands, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Changes
Added missing LinkedIn URLs for several team members in the `README.md` team table.

<!-- Provide a brief description of what this PR does -->

## How did you test this code?

Verified that all LinkedIn URLs are correctly formatted and link to the right profiles.
- Checked the table formatting in the `README.md` to ensure it renders properly on GitHub.
<!-- Describe how you tested your changes -->

## Related Issue

<!-- Link to the related issue or ticket -->
Closes #58

---

## Testing Checklist

- [ x ] I have tested my changes locally
- [ x ] I have run `pnpm run lint` and fixed all errors
- [ x ] I have run `pnpm run build` and it succeeds
- [ x ] I have run `pnpm run test` and all tests pass

## Contribution Checklist

- [ x ] My branch is up to date with upstream/main
- [ x ] My changes are focused on a single task (granular PR)
- [ x ] I have followed the project's code style guidelines
- [x  ] I have updated any relevant documentation
- [x  ] My commit messages are clear and descriptive
- [x  ] I have linked the related issue/ticket
- [ x ] All acceptance criteria from the ticket are met
