### PR TITLE
feat(frontend): implement ProtectedRoute and wrap dashboard layout

### DIFF
--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+import { ProtectedRoute } from '@/src/components/auth/ProtectedRoute';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <ProtectedRoute>
+            <div className="flex min-h-screen bg-gray-50">
+                <aside className="w-64 border-r bg-white p-4">
+                    <nav className="font-bold">Dashboard Nav</nav>
+                </aside>
+                <main className="flex-1 p-8">
+                    {children}
+                </main>
+            </div>
+        </ProtectedRoute>
+    );
+}

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+
+export default function DashboardPage() {
+    return (
+        <div className="rounded-lg bg-white p-8 shadow-sm">
+            <h1 className="text-2xl font-bold">Welcome to your Dashboard</h1>
+            <p className="mt-2 text-gray-600">This content is protected by the auth guard.</p>
+        </div>
+    );
+}

--- a/apps/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuthStore } from '@/src/store/useAuthStore';
+
+export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+    const { token, isInitialized, initialize } = useAuthStore();
+    const router = useRouter();
+    const pathname = usePathname();
+
+    // Initialize the store from localStorage on mount
+    useEffect(() => {
+        if (!isInitialized) {
+            initialize();
+        }
+    }, [isInitialized, initialize]);
+
+    // Handle Redirection
+    useEffect(() => {
+        // Logic: If check is done (isInitialized) and no token exists
+        if (isInitialized && !token) {
+            const searchParams = new URLSearchParams({ redirectTo: pathname });
+            router.push(`/login?${searchParams.toString()}`);
+        }
+    }, [isInitialized, token, router, pathname]);
+
+    // Loading state to prevent "flashing" protected content
+    if (!isInitialized) {
+        return (
+            <div className="flex h-screen w-full items-center justify-center bg-white">
+                <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-600 border-t-transparent"></div>
+            </div>
+        );
+    }
+
+    // Hide UI while redirecting
+    if (!token) return null;
+
+    return <>{children}</>;
+};


### PR DESCRIPTION
## Changes

<!-- Provide a brief description of what this PR does -->
Created a reusable ProtectedRoute client-side guard component in apps/frontend/src/components/auth/

Integrated with useAuthStore to check for token and isInitialized states.

Implemented a full-page Loading Spinner to prevent "flashing" of protected content.

Added redirection logic that appends the current path as a redirectTo query parameter for better UX.

Wrapped the Dashboard Layout (/dashboard) with the guard to secure all nested routes.



## How did you test this code?

<!-- Describe how you tested your changes -->
Verified that visiting /dashboard while logged out redirects to /login?redirectTo=%2Fdashboard.

 Verified that refreshing the dashboard while logged in shows the loading spinner briefly and maintains the session without redirecting.

Confirmed that  /dashboard/settings (if they existed) is redirects to /login?redirectTo=%2Fdashboard%2Fsettings.

## Related Issue

<!-- Link to the related issue or ticket -->
Closes #34

---

## Testing Checklist

- [x] I have tested my changes locally
- [x] I have run `pnpm run lint` and fixed all errors
- [x] I have run `pnpm run build` and it succeeds
- [ ] I have run `pnpm run test` and all tests pass

## Contribution Checklist

- [x] My branch is up to date with upstream/main
- [x] My changes are focused on a single task (granular PR)
- [x] I have followed the project's code style guidelines
- [ ] I have updated any relevant documentation
- [x] My commit messages are clear and descriptive
- [x] I have linked the related issue/ticket
- [x] All acceptance criteria from the ticket are met
